### PR TITLE
fix: 文本按钮 isOnlyIcon 宽高不相等问题

### DIFF
--- a/base-components/src/button/main.scss
+++ b/base-components/src/button/main.scss
@@ -51,6 +51,7 @@ $text-btn: $btn-prefix + '-text';
     }
     &:not(#{$wind-cls}).isOnlyIcon {
       width: 24px;
+      height: 24px;
       padding: 0;
     }
   }
@@ -69,6 +70,7 @@ $text-btn: $btn-prefix + '-text';
     }
     &:not(#{$wind-cls}).isOnlyIcon {
       width: 32px;
+      height: 32px;
       padding: 0;
     }
   }
@@ -87,6 +89,7 @@ $text-btn: $btn-prefix + '-text';
     }
     &:not(#{$wind-cls}).isOnlyIcon {
       width: 36px;
+      height: 36px;
       padding: 0;
     }
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10082151/155982910-d9cfc793-49e1-4254-960b-bcdd40ff511e.png)

```jsx
<Button text>
   <Icon type="search" />
</Button>
```

这种用法的单图标按钮，高度和宽度不一样，高度固定为20px，因此把高度也设置下
